### PR TITLE
カテゴリを設定しない場合に無限ループが発生する不具合を修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "dynamic-timetable",
 	"name": "Dynamic Timetable",
-	"version": "4.5.0",
+	"version": "4.5.1",
 	"minAppVersion": "1.2.8",
 	"description": "Calculate the estimated time of completion from the estimated time of the task and dynamically create a timetable.",
 	"author": "L7Cy",

--- a/src/TimetableViewComponent.tsx
+++ b/src/TimetableViewComponent.tsx
@@ -115,10 +115,10 @@ const TimetableViewComponent = forwardRef<
         }
         newBackgroundColors[category] = color;
         document.documentElement.style.setProperty(`--${className}-bg`, color);
-        if (!plugin.isCategoryColorsReady) {
-          plugin.isCategoryColorsReady = true;
-        }
       });
+      if (!plugin.isCategoryColorsReady) {
+        plugin.isCategoryColorsReady = true;
+      }
     });
 
     setCategoryBackgroundColors(newBackgroundColors);


### PR DESCRIPTION
いつもこのプラグインを便利に使わせていただいております。ありがとうございます。

最新版が私の環境で動かずv.4.1.5を利用していたのですが、
v4.5.0で問題を特定し、コードを修正したら動いたため共有します。

## 環境
OS: Windows 11
Obsidian version: v.1.4.16
Plugin version: v.4.5.0

## 問題
全てのタスクでカテゴリが設定されていない場合に全てのコマンドが動作しない。

## 原因
カテゴリを利用しない場合に、下記コードで`this.isCategoryColorsReady`がtrueにならず無限ループが発生する。

https://github.com/L7Cy/obsidian-dynamic-timetable/blob/master/src/main.ts#L165-L167

## 対処
カテゴリを利用していなくとも、`this.isCategoryColorsReady`がtrueになるようにする。
カテゴリを利用している場合も、処理の終了後に`this.isCategoryColorsReady`がtrueになる。